### PR TITLE
fix: broken links

### DIFF
--- a/src/components/HomePageHeader/index.tsx
+++ b/src/components/HomePageHeader/index.tsx
@@ -125,7 +125,7 @@ const HomeHead: FC = () => {
                 size="lg"
                 variant="primary"
                 className="fw-normal fs-20 btnMain me-3"
-                href="docs"
+                href="/docs"
               >
                 <Translate id="home.btn.started">Get Started</Translate>
               </Button>

--- a/src/pages/plugins.tsx
+++ b/src/pages/plugins.tsx
@@ -22,11 +22,11 @@ export default function Plugins(): JSX.Element {
       <HeaderSlogan type="plugin" />
       <Container className='py-5'>
          <div style={{ fontSize: '1.25rem' }}>
-            <a href="docs/plugins">
+            <a href="/docs/plugins">
               <Translate id="plugins.instruction.install">Install plugins</Translate>
             </a>
             {' · '}
-            <a href="community/plugins">
+            <a href="/community/plugins">
               <Translate id="plugins.instruction.create">Create a plugin</Translate>
             </a>
             {' · '}


### PR DESCRIPTION
**Description**

![image](https://github.com/apache/incubator-answer-website/assets/2253237/0be0426e-a3ef-43df-b3c0-e35d1ebf8dbd)

**To Reproduce**
Visit this link directly, click "Install plugins" or "Create a plugin"
https://answer.apache.org/plugins

**Expected behavior**
Should link to 
https://answer.apache.org/docs/plugins
https://answer.apache.org/community/plugins
